### PR TITLE
CL-943 Stop `close()` from blowing up

### DIFF
--- a/Charon/filetypes/UltimakerFormatPackage.py
+++ b/Charon/filetypes/UltimakerFormatPackage.py
@@ -61,8 +61,9 @@ class UltimakerFormatPackage(FileInterface):
     def close(self) -> None:
         if not self._stream:
             raise ValueError("This file is already closed.")
-        assert self._zipfile is not None
-        
+        if self._zipfile is None:
+            return
+
         self.flush()
         self._zipfile.close()
 


### PR DESCRIPTION
`close()` can explode in the case that `__init__()` failed. The `__del__()`
method in VirtualFile always calls `close()`, regardless of whether the
constructor was successful.

CL-943 https://jira.ultimaker.com:8443/browse/CL-943