### PR TITLE
EM-3495 Fix syntax error in cancel request

### DIFF
--- a/Charon/Service/FileService.py
+++ b/Charon/Service/FileService.py
@@ -56,7 +56,7 @@ class FileService(dbus.service.Object):
     #   \param request_id The ID of the request to cancel.
     @dbus.decorators.method("nl.ultimaker.charon", "s", "")
     def cancelRequest(self, request_id):
-        log.debug("Cancel request {id}".format(request_id))
+        log.debug("Cancel request '{id}'".format(id = request_id))
         if self.__queue.dequeue(request_id):
             self.requestError(request_id, "Request canceled")
 


### PR DESCRIPTION
The cancel request has a debug log message with a syntax error. This will create a stack trace and might cause the service to terminate (I didn't check if this exception is caught).

The log message is formatted using the format() function which causes this command to be always executed, independent on the set logging level.