### PR TITLE
Use exact Python version when identifying the interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
     set(Python3_VERSION_MINOR ${PYTHON_VERSION_MINOR})
 else()
     # Use FindPython3 for CMake >=3.12
-    find_package(Python3 3.4 REQUIRED COMPONENTS Interpreter)
+    find_package(Python3 ${CURA_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
 endif()
 
 option(INSTALL_SERVICE "Install the Charon DBus-service" ON)


### PR DESCRIPTION
The Python version that Cura is currently using is v3.5.7 and after the upgrade it will be v3.8.8. However, the macOS builder VM on AWS has already a system Python installed which is version 3.9.1.
As a result, during CMake's configuration step for libCharon the system Python is detected first (since it's located in `/usr/bin`) and, thus, the step results in error.
Using an exact version of Python in the CMakeLists file and setting that variable during the configuration step is the most ideal solution for this issue.