### PR TITLE
Change the variable name for the python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
     set(Python3_VERSION_MINOR ${PYTHON_VERSION_MINOR})
 else()
     # Use FindPython3 for CMake >=3.12
-    find_package(Python3 ${CURA_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+    find_package(Python3 ${PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
 endif()
 
 option(INSTALL_SERVICE "Install the Charon DBus-service" ON)


### PR DESCRIPTION
After internal review of our CURA-7900 ticket it was decided to use the more broad `PYTHON_VERSION` naming and omit the `CURA` reference.