### PR TITLE
CES-603 TCP sockets

### DIFF
--- a/Charon/VirtualFile.py
+++ b/Charon/VirtualFile.py
@@ -15,7 +15,7 @@ extension_to_mime = {
     ".gcode": "text/x-gcode",
     ".gz": "text/x-gcode-gz",
     ".gcode.gz": "text/x-gcode-gz",
-    ".sock": "text/x-gcode-sock"
+    ".sock": "text/x-gcode-socket"
 }
 
 mime_to_implementation = {

--- a/Charon/VirtualFile.py
+++ b/Charon/VirtualFile.py
@@ -5,10 +5,10 @@ import os
 from Charon.FileInterface import FileInterface  # The interface we're implementing.
 from Charon.OpenMode import OpenMode  #To open local files with the selected open mode.
 # The supported file types.
-from Charon.filetypes import GCodeSocket
 from Charon.filetypes.UltimakerFormatPackage import UltimakerFormatPackage
 from Charon.filetypes.GCodeFile import GCodeFile
 from Charon.filetypes.GCodeGzFile import GCodeGzFile
+from Charon.filetypes.GCodeSocket import GCodeSocket
 
 extension_to_mime = {
     ".ufp": "application/x-ufp",

--- a/Charon/VirtualFile.py
+++ b/Charon/VirtualFile.py
@@ -5,6 +5,7 @@ import os
 from Charon.FileInterface import FileInterface  # The interface we're implementing.
 from Charon.OpenMode import OpenMode  #To open local files with the selected open mode.
 # The supported file types.
+from Charon.filetypes import GCodeSocket
 from Charon.filetypes.UltimakerFormatPackage import UltimakerFormatPackage
 from Charon.filetypes.GCodeFile import GCodeFile
 from Charon.filetypes.GCodeGzFile import GCodeGzFile

--- a/Charon/VirtualFile.py
+++ b/Charon/VirtualFile.py
@@ -13,13 +13,15 @@ extension_to_mime = {
     ".ufp": "application/x-ufp",
     ".gcode": "text/x-gcode",
     ".gz": "text/x-gcode-gz",
-    ".gcode.gz": "text/x-gcode-gz"
+    ".gcode.gz": "text/x-gcode-gz",
+    ".sock": "text/x-gcode-sock"
 }
 
 mime_to_implementation = {
     "application/x-ufp": UltimakerFormatPackage,
     "text/x-gcode": GCodeFile,
-    "text/x-gcode-gz": GCodeGzFile
+    "text/x-gcode-gz": GCodeGzFile,
+    "text/x-gcode-socket": GCodeSocket
 }
 
 

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -33,7 +33,8 @@ class GCodeSocket(GCodeFile):
         if path.startswith('file://'):
             print('OOOOPS: socket path contains protocol specifier')
             path = path.replace('file://', '')
-        sock = socket.socket(socket.AF_UNIX, path)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(path)
         file_stream = sock.makefile('r', buffering=0)
 
         # Hijack readline() so we can acknowledge every line we

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -85,6 +85,7 @@ class GCodeSocket(GCodeFile):
         if path.startswith('socket://'):
             print('OOOOPS: socket path contains protocol specifier')
             path = path.replace('socket://', '')
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.connect(path)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        
+        sock.connect((path, 1337))
         return SocketFileStream(sock)

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -7,6 +7,7 @@ from io import TextIOBase, BytesIO, SEEK_SET, SEEK_CUR
 from typing import Any, Dict, IO, TextIO, Optional, AnyStr, List
 
 from Charon.filetypes.GCodeFile import GCodeFile
+from urllib.parse import urlparse
 
 
 def isAPositiveNumber(a: str) -> bool:
@@ -82,10 +83,7 @@ class GCodeSocket(GCodeFile):
 
     @staticmethod
     def stream_handler(path: str, mode: str) -> IO:
-        if path.startswith('socket://'):
-            print('OOOOPS: socket path contains protocol specifier')
-            path = path.replace('socket://', '')
+        url = urlparse(path)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        
-        sock.connect((path, 1337))
+        sock.connect((url.hostname, 1337))
         return SocketFileStream(sock)

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -33,7 +33,7 @@ class GCodeSocket(GCodeFile):
         if path.startswith('file://'):
             print('OOOOPS: socket path contains protocol specifier')
             path = path.replace('file://', '')
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(path)
         file_stream = sock.makefile('r', buffering=0)
 

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# libCharon is released under the terms of the LGPLv3 or higher.
+import ast, socket
+
+from typing import Any, Dict, IO, List, Optional, Union
+
+from Charon.FileInterface import FileInterface
+from Charon.filetypes import GCodeFile
+from Charon.OpenMode import OpenMode
+
+
+def isAPositiveNumber(a: str) -> bool:
+    try:
+        number = float(repr(a))
+        return number >= 0
+    except:
+        bool_a = False
+
+    return bool_a
+
+
+class GCodeSocket(GCodeFile):
+    mime_type = "text/x-gcode-socket"
+
+    MaximumHeaderLength = 100
+
+    def __init__(self) -> None:
+        super.__init__(self)
+        self.__stream = None  # type: Optional[IO[bytes]]
+        self.__metadata = {}  # type: Dict[str, Any]
+        self.__sock = None
+
+    @staticmethod
+    def stream_handler(path):
+        if path.startswith('file://'):
+            print('OOOOPS: socket path contains protocol specifier')
+            path = path.replace('file://', '')
+        self.__sock = socket.socket(socket.AF_UNIX, path)
+        file_stream = self.__sock.makefile('w', buffering=0)
+
+        # Hijack readline() so we can acknowledge every line we
+        # read from the socket
+        old_readline = file_stream.readline
+        def hacked_readline():
+            line = old_readline()
+            if line != "":
+                self.__sock.send(b'0x01')
+            return line
+        file_stream.readline = hacked_readline
+
+
+    def close(self) -> None:
+        assert self.__stream is not None
+        
+        self.__stream.close()
+        self.__sock.close()

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -33,7 +33,7 @@ class GCodeSocket(GCodeFile):
         if path.startswith('file://'):
             print('OOOOPS: socket path contains protocol specifier')
             path = path.replace('file://', '')
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
         sock.connect(path)
         file_stream = sock.makefile('r', buffering=0)
 

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -4,7 +4,7 @@ import socket
 
 from typing import Any, Dict, IO, TextIO, Optional
 
-from Charon.filetypes import GCodeFile
+from Charon.filetypes.GCodeFile import GCodeFile
 
 
 def isAPositiveNumber(a: str) -> bool:
@@ -23,7 +23,7 @@ class GCodeSocket(GCodeFile):
     MaximumHeaderLength = 100
 
     def __init__(self) -> None:
-        super.__init__(self)
+        super().__init__()
         self.__stream = None  # type: Optional[IO[bytes]]
         self.__metadata = {}  # type: Dict[str, Any]
         self.__sock = None

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -47,11 +47,18 @@ class GCodeSocket(GCodeFile):
                 sock.send(b'0x01')
             return line
         file_stream.readline = hacked_readline
+
+        old_close = file_stream.close
+
+        def hacked_close():
+            old_close()
+            sock.close()
+
+        file_stream.close = hacked_close
         return file_stream
 
     def close(self) -> None:
-        pass
-        # assert self.__stream is not None
-        #
-        # self.__stream.close()
-        # self.__sock.close()
+        # self.__stream is set by super's openStream()
+        assert self.__stream is not None
+        # and this calls hacked_close(), which closes both the file stream and the underlying socket
+        self.__stream.close()

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -44,10 +44,10 @@ class SocketFileStream(BytesIO):
         self.current_line += 1
         return line
 
-    def read(self, __size: Optional[int] = None) -> str:
+    def read(self, __size: Optional[int] = None) -> bytes:
         assert False
 
-    def readlines(self, __hint: Optional[int] = None) -> List[str]:
+    def readlines(self, __hint: Optional[int] = None) -> List[bytes]:
         assert False
 
     def tell(self) -> int:

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -32,7 +32,7 @@ class SocketFileStream(BytesIO):
             raise ValueError('Unsupported whence mode in seek: %d' % whence)
         return offset
 
-    def readline(self, limit: Optional[int] = None) -> bytes:
+    def readline(self, _size: int = -1) -> bytes:
         self.__socket.send(struct.pack('>I', self.current_line))
         line = b''
         char = b''
@@ -44,10 +44,10 @@ class SocketFileStream(BytesIO):
         self.current_line += 1
         return line
 
-    def read(self, __size: Optional[int] = None) -> bytes:
+    def read(self, _size: int = -1) -> bytes:
         assert False
 
-    def readlines(self, __hint: Optional[int] = None) -> List[bytes]:
+    def readlines(self, _hint: int = -1) -> List[bytes]:
         assert False
 
     def tell(self) -> int:

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # libCharon is released under the terms of the LGPLv3 or higher.
 import socket
+import struct
+from io import TextIOBase, BytesIO, SEEK_SET, SEEK_CUR
 
-from typing import Any, Dict, IO, TextIO, Optional
+from typing import Any, Dict, IO, TextIO, Optional, AnyStr, List
 
 from Charon.filetypes.GCodeFile import GCodeFile
 
@@ -10,11 +12,61 @@ from Charon.filetypes.GCodeFile import GCodeFile
 def isAPositiveNumber(a: str) -> bool:
     try:
         number = float(repr(a))
+        x = open()
         return number >= 0
     except:
         bool_a = False
 
     return bool_a
+
+
+class SocketFileStream(BytesIO):
+    def __init__(self, sock_object: socket.socket):
+        super().__init__()
+        self.current_line = 0
+        self.__socket = sock_object
+
+    def seekable(self) -> bool:
+        return True
+
+    def seek(self, offset: int, whence: Optional[int] = None) -> int:
+        if whence is None or whence == SEEK_SET:
+            self.current_line = offset
+        elif whence == SEEK_CUR:
+            self.current_line += offset
+        else:
+            raise ValueError('Unsupported whence mode in seek: %d' % whence)
+        return offset
+
+    def readline(self, limit: Optional[int] = None) -> bytes:
+        self.__socket.send(struct.pack('>I', self.current_line))
+        line = b''
+        char = b''
+
+        while char != b'\n':
+            char = self.__socket.recv(1)
+            line += char
+
+        self.current_line += 1
+        return line
+
+    def read(self, __size: Optional[int] = None) -> str:
+        assert False
+
+    def readlines(self, __hint: Optional[int] = None) -> List[str]:
+        assert False
+
+    def tell(self) -> int:
+        assert False
+
+    def close(self):
+        self.__socket.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.readline()
 
 
 class GCodeSocket(GCodeFile):
@@ -29,36 +81,10 @@ class GCodeSocket(GCodeFile):
         self.__sock = None
 
     @staticmethod
-    def stream_handler(path: str) -> TextIO:
-        if path.startswith('file://'):
+    def stream_handler(path: str, mode: str) -> IO:
+        if path.startswith('socket://'):
             print('OOOOPS: socket path contains protocol specifier')
-            path = path.replace('file://', '')
+            path = path.replace('socket://', '')
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(path)
-        file_stream = sock.makefile('r', buffering=0)
-
-        # Hijack readline() so we can acknowledge every line we
-        # read from the socket
-        old_readline = file_stream.readline
-
-        def hacked_readline():
-            line = old_readline()
-            if line != "":
-                sock.send(b'0x01')
-            return line
-        file_stream.readline = hacked_readline
-
-        old_close = file_stream.close
-
-        def hacked_close():
-            old_close()
-            sock.close()
-
-        file_stream.close = hacked_close
-        return file_stream
-
-    def close(self) -> None:
-        # self.__stream is set by super's openStream()
-        assert self.__stream is not None
-        # and this calls hacked_close(), which closes both the file stream and the underlying socket
-        self.__stream.close()
+        return SocketFileStream(sock)

--- a/Charon/filetypes/GCodeSocket.py
+++ b/Charon/filetypes/GCodeSocket.py
@@ -1,24 +1,17 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # libCharon is released under the terms of the LGPLv3 or higher.
+#
+# This class is used to read GCode stream that are served
+# dynamically over a TCP connection.
+
 import socket
 import struct
-from io import TextIOBase, BytesIO, SEEK_SET, SEEK_CUR
+from io import BytesIO, SEEK_SET, SEEK_CUR
 
-from typing import Any, Dict, IO, TextIO, Optional, AnyStr, List
+from typing import Any, Dict, IO, Optional, List
 
 from Charon.filetypes.GCodeFile import GCodeFile
 from urllib.parse import urlparse
-
-
-def isAPositiveNumber(a: str) -> bool:
-    try:
-        number = float(repr(a))
-        x = open()
-        return number >= 0
-    except:
-        bool_a = False
-
-    return bool_a
 
 
 class SocketFileStream(BytesIO):

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -30,7 +30,7 @@ env_check()
 
 run_build()
 {
-    run_in_docker "./build.sh" "${@:-}"
+    run_in_docker "./build.sh" "${@}"
 }
 
 deliver_pkg()
@@ -114,7 +114,7 @@ if [ "${run_linters}" = "yes" ]; then
     run_linters
 fi
 
-run_build "${@:-}"
+run_build "${@}"
 
 if [ "${run_tests}" = "yes" ]; then
     run_tests

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -30,7 +30,7 @@ env_check()
 
 run_build()
 {
-    run_in_docker "./build.sh" "${@}"
+    run_in_docker "./build.sh" "${@:-}"
 }
 
 deliver_pkg()
@@ -114,7 +114,7 @@ if [ "${run_linters}" = "yes" ]; then
     run_linters
 fi
 
-run_build "${@}"
+run_build "${@:-}"
 
 if [ "${run_tests}" = "yes" ]; then
     run_tests

--- a/ci/mypy.sh
+++ b/ci/mypy.sh
@@ -2,13 +2,13 @@
 
 set -eu
 
-MYPY_FILES=$(git diff --name-only --diff-filter=d origin/master | grep -i .py$ | cat)
+MYPY_FILES=$(git diff --name-only --diff-filter=d origin/colorado_baseline | grep -i .py$ | cat)
 
 if [ -n "${MYPY_FILES}" ] ; then
     echo "Testing ${MYPY_FILES}"
     for file in ${MYPY_FILES} ; do
         echo "Mypying ${file}"
-        mypy --config-file=mypy.ini --cache-dir=/dev/null "${file}"
+        mypy --config-file=mypy.ini --follow-imports=skip --cache-dir=/dev/null "${file}"
     done
 fi
 


### PR DESCRIPTION
Enables the use of tcp socket connections to read gcode.
The file path used for this should be something like: `tcp://192.169.0.5/dummy.sock`. This is due to the fact the charon only checks for file extensions.