### PR TITLE
CS-2323 `_aliases`: Do not replace non-top-level directories

### DIFF
--- a/Charon/filetypes/GCodeFile.py
+++ b/Charon/filetypes/GCodeFile.py
@@ -96,7 +96,7 @@ class GCodeFile(FileInterface):
     @staticmethod
     def __insertKeyValuePair(
         metadata: Dict[str, Any],
-        key_elements: Union[str, List[str]],
+        key_elements: Any,
         value: Any
     ) -> Any:
         if not key_elements:
@@ -151,7 +151,7 @@ class GCodeFile(FileInterface):
     #             must exist on the location of that key element
     # @return True if the key is available and not empty
     @staticmethod
-    def __isAvailable(metadata: Dict[str, Any], keys: List[str]) -> None:
+    def __isAvailable(metadata: Dict[str, Any], keys: List[Any]) -> bool:
         if not keys:
             return True
 

--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -25,7 +25,7 @@ class OpenPackagingConvention(FileInterface):
     _global_metadata_file = "/Metadata/OPC_Global.json"  # Where the global metadata file is.
     _opc_metadata_relationship_type = "http://schemas.ultimaker.org/package/2018/relationships/opc_metadata"  # Unique identifier of the relationship type that relates OPC metadata to files.
     _metadata_prefix = "/metadata"
-    _aliases = OrderedDict([])  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
+    _aliases = OrderedDict([])  # type: Dict[str, Any]  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
 
     mime_type = "application/x-opc"
 

--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -298,7 +298,11 @@ class OpenPackagingConvention(FileInterface):
 
         # Replace all aliases.
         for regex, replacement in self._aliases.items():
-            virtual_path = re.sub(regex, replacement, virtual_path)
+            if regex.startswith("/"):
+                expression = r"^" + regex
+            else:
+                expression = regex
+            virtual_path = re.sub(expression, replacement, virtual_path)
 
         return virtual_path
 

--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -25,7 +25,7 @@ class OpenPackagingConvention(FileInterface):
     _global_metadata_file = "/Metadata/OPC_Global.json"  # Where the global metadata file is.
     _opc_metadata_relationship_type = "http://schemas.ultimaker.org/package/2018/relationships/opc_metadata"  # Unique identifier of the relationship type that relates OPC metadata to files.
     _metadata_prefix = "/metadata"
-    _aliases = OrderedDict([])  # type: Dict[str, Any]  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
+    _aliases:Dict[str, str] = OrderedDict([])  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
 
     mime_type = "application/x-opc"
 

--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -299,7 +299,7 @@ class OpenPackagingConvention(FileInterface):
         # Replace all aliases.
         for regex, replacement in self._aliases.items():
             if regex.startswith("/"):
-                expression = r"^" + regex
+                expression = rf"^{regex}"
             else:
                 expression = regex
             virtual_path = re.sub(expression, replacement, virtual_path)

--- a/tests/filetypes/TestOpenPackagingConvention.py
+++ b/tests/filetypes/TestOpenPackagingConvention.py
@@ -6,7 +6,7 @@ import pytest #This module contains unit tests.
 import zipfile #To inspect the contents of the zip archives.
 import xml.etree.ElementTree as ET #To inspect the contents of the OPC-spec files in the archives.
 from collections import OrderedDict
-from typing import List
+from typing import List, Generator
 
 from Charon.filetypes.OpenPackagingConvention import OpenPackagingConvention, OPCError  # The class we're testing.
 from Charon.OpenMode import OpenMode #To open archives.
@@ -16,7 +16,7 @@ from Charon.OpenMode import OpenMode #To open archives.
 #   The package has no resources at all, so reading from it will not find
 #   anything.
 @pytest.fixture()
-def empty_read_opc() -> OpenPackagingConvention:
+def empty_read_opc() -> Generator[OpenPackagingConvention, None, None]:
     result = OpenPackagingConvention()
     result.openStream(open(os.path.join(os.path.dirname(__file__), "resources", "empty.opc"), "rb"))
     yield result
@@ -28,7 +28,7 @@ def empty_read_opc() -> OpenPackagingConvention:
 #   The file is called "hello.txt" and contains the text "Hello world!" encoded
 #   in UTF-8.
 @pytest.fixture()
-def single_resource_read_opc() -> OpenPackagingConvention:
+def single_resource_read_opc() -> Generator[OpenPackagingConvention, None, None]:
     result = OpenPackagingConvention()
     result.openStream(open(os.path.join(os.path.dirname(__file__), "resources", "hello.opc"), "rb"))
     yield result
@@ -40,7 +40,7 @@ def single_resource_read_opc() -> OpenPackagingConvention:
 #   Note that you can't really test the output of the write since you don't have
 #   the stream it writes to.
 @pytest.fixture()
-def empty_write_opc() -> OpenPackagingConvention:
+def empty_write_opc() -> Generator[OpenPackagingConvention, None, None]:
     result = OpenPackagingConvention()
     result.openStream(io.BytesIO(), "application/x-opc", OpenMode.WriteOnly)
     yield result


### PR DESCRIPTION
In OpenPackagingConvention, the `_processAliases` method simply does the replacement by `re.sub()`. But we only want the top-level directory to be replaced, for example:

👍: `/materials/something.txt` --> `/files/materials/something.txt`
👎: `/something/materials/foobar.txt` --> `/something/files/materials/foobar.txt`

This is the fix.

Note: pathlib is not used here because usually a `Path` object needs to be actually resolvable. A `PurePath` object doesn't need to be resolvable, but it doesn't have the method to rename/replace. Therefore `re.sub()` is still used for the fix.