### PR TITLE
Python 3.4, print-cluster, backward compatibility

### DIFF
--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -25,7 +25,7 @@ class OpenPackagingConvention(FileInterface):
     _global_metadata_file = "/Metadata/OPC_Global.json"  # Where the global metadata file is.
     _opc_metadata_relationship_type = "http://schemas.ultimaker.org/package/2018/relationships/opc_metadata"  # Unique identifier of the relationship type that relates OPC metadata to files.
     _metadata_prefix = "/metadata"
-    _aliases:Dict[str, str] = OrderedDict([])  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
+    _aliases = OrderedDict([])  # type: Dict[str, str]  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
 
     mime_type = "application/x-opc"
 

--- a/Charon/filetypes/OpenPackagingConvention.py
+++ b/Charon/filetypes/OpenPackagingConvention.py
@@ -299,7 +299,7 @@ class OpenPackagingConvention(FileInterface):
         # Replace all aliases.
         for regex, replacement in self._aliases.items():
             if regex.startswith("/"):
-                expression = rf"^{regex}"
+                expression = r"^" + regex
             else:
                 expression = regex
             virtual_path = re.sub(expression, replacement, virtual_path)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+python_version = 3.4
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
Fix: Use comment for typing indication for backward compatibility

print-cluster still uses Python 3.4. In that version the modern typing `_aliases: Dict[str, str]` had not been included in the syntax yet. Therefore the only thing we can do is to put it in the comment instead.

Furthermore: f-string is removed from this PR, as it was introduced in Python 3.6, not in 3.4 yet 😫

```
Traceback (most recent call last):
  File "extract_swagger_api.py", line 9, in <module>
    from app.apiv1 import api
  File "/source/app/apiv1.py", line 4, in <module>
    from app.apis.debug import ns as debug
  File "/source/app/apis/debug.py", line 9, in <module>
    from app.services.scheduler.result_containers.planner_result_schedule import PlannerResultSchedule
  File "/source/app/services/scheduler/result_containers/planner_result_schedule.py", line 3, in <module>
    from app.models.print_job import PrintJob
  File "/source/app/models/print_job.py", line 8, in <module>
    import Charon.VirtualFile
  File "/usr/local/lib/python3.4/dist-packages/Charon/VirtualFile.py", line 8, in <module>
    from Charon.filetypes.UltimakerFormatPackage import UltimakerFormatPackage
  File "/usr/local/lib/python3.4/dist-packages/Charon/filetypes/UltimakerFormatPackage.py", line 7, in <module>
    from Charon.filetypes.OpenPackagingConvention import OpenPackagingConvention
  File "/usr/local/lib/python3.4/dist-packages/Charon/filetypes/OpenPackagingConvention.py", line 28
    _aliases:Dict[str, str] = OrderedDict([])  # A standard OPC file doest not have default aliases. These must be implemented in inherited classes.
            ^
SyntaxError: invalid syntax
```