### PR TITLE
Cura 8640 PyQt6 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,25 @@
 project(charon NONE)
-cmake_minimum_required(VERSION 3.6) #Tested only with 3.6.1 and 3.9.1.
+cmake_minimum_required(VERSION 3.18)
 
-# FIXME: Remove the code for CMake <3.12 once we have switched over completely.
-# FindPython3 is a new module since CMake 3.12. It deprecates FindPythonInterp and FindPythonLibs.
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-    # Use FindPythonInterp and FindPythonLibs for CMake <3.12
-    find_package(PythonInterp 3.4 REQUIRED)
-
-    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-    set(Python3_VERSION_MAJOR ${PYTHON_VERSION_MAJOR})
-    set(Python3_VERSION_MINOR ${PYTHON_VERSION_MINOR})
-else()
-    # Use FindPython3 for CMake >=3.12
-    find_package(Python3 ${CURA_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+if(NOT DEFINED Python_VERSION)
+    set(Python_VERSION
+            3.10
+            CACHE STRING "Python Version" FORCE)
+    message(STATUS "Setting Python version to ${Python_VERSION}. Set Python_VERSION if you want to compile against an other version.")
+endif()
+if(APPLE)
+    set(Python_FIND_FRAMEWORK NEVER)
+endif()
+find_package(Python ${Python_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+message(STATUS "Linking and building ${project_name} against Python ${Python_VERSION}")
+if(NOT DEFINED Python_SITELIB_LOCAL)
+    set(Python_SITELIB_LOCAL
+            "${Python_SITELIB}"
+            CACHE PATH "Local alternative site-package location to install Cura" FORCE)
 endif()
 
 option(INSTALL_SERVICE "Install the Charon DBus-service" ON)
 option(INSTALL_CLIENT "Install the Charon Client library" ON)
-
-if(EXISTS /etc/debian_version)
-    set(CHARON_INSTALL_PATH lib${LIB_SUFFIX}/python${Python3_VERSION_MAJOR}/dist-packages)
-else()
-    set(CHARON_INSTALL_PATH lib${LIB_SUFFIX}/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages)
-endif()
 
 set(_excludes PATTERN __pycache__ EXCLUDE)
 if(NOT INSTALL_SERVICE)
@@ -32,7 +29,7 @@ if(NOT INSTALL_CLIENT)
     set(_excludes ${_excludes} PATTERN "Client" EXCLUDE)
 endif()
 
-install(DIRECTORY Charon DESTINATION ${CHARON_INSTALL_PATH} ${_excludes})
+install(DIRECTORY Charon DESTINATION ${Python_SITELIB_LOCAL} ${_excludes})
 
 if(INSTALL_SERVICE)
     install(FILES service/charon.service DESTINATION lib/systemd/system)
@@ -59,7 +56,7 @@ endif()
 
 add_test(
     NAME pytest-main
-    COMMAND ${Python3_EXECUTABLE} -m pytest --junitxml=${CMAKE_BINARY_DIR}/junit-pytest-main.xml ${CMAKE_SOURCE_DIR}/tests
+    COMMAND ${Python_EXECUTABLE} -m pytest --junitxml=${CMAKE_BINARY_DIR}/junit-pytest-main.xml ${CMAKE_SOURCE_DIR}/tests
 )
 set_tests_properties(pytest-main PROPERTIES ENVIRONMENT LANG=C)
 set_tests_properties(pytest-main PROPERTIES ENVIRONMENT "PYTHONPATH=${_PYTHONPATH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,15 +21,7 @@ endif()
 option(INSTALL_SERVICE "Install the Charon DBus-service" ON)
 option(INSTALL_CLIENT "Install the Charon Client library" ON)
 
-set(_excludes PATTERN __pycache__ EXCLUDE)
-if(NOT INSTALL_SERVICE)
-    set(_excludes ${_excludes} PATTERN "Service" EXCLUDE)
-endif()
-if(NOT INSTALL_CLIENT)
-    set(_excludes ${_excludes} PATTERN "Client" EXCLUDE)
-endif()
-
-install(DIRECTORY Charon DESTINATION ${Python_SITELIB_LOCAL} ${_excludes})
+install(DIRECTORY Charon DESTINATION "${Python_SITELIB_LOCAL}")
 
 if(INSTALL_SERVICE)
     install(FILES service/charon.service DESTINATION lib/systemd/system)


### PR DESCRIPTION
In order to get this to work on our build-system and working for all three OSes we did a shit tons of boy scouting in our cmake. We removed old methods with variables and try to be consisted in a target-based approach. The idea is that we don't patch stuff down the line, but that the install should place everything in the correct path in a uniform way across all of Cura's dependencies.

These changes have been tested for the Cura team and not yet by the Styx team. Since we're merging to 5.0 instead of master I think we can continue with the PR anyway.

Most of the changes had to do with how dependency targets were named and to make sure that external projects weren't downloaded automatically.

# Part of
- ultimaker/libarcus#134
- ultimaker/pynest2d#17
- ultimaker/libsavitar#41
- ultimaker/libnest2d#3
- ultimaker/cura-binary-data#17
- ultimaker/curaengine#1639
- ultimaker/uranium#804
- ultimaker/cura#11792
- ultimaker/cura-build-environment#126
- ultimaker/cura-build#280
- ultimaker/cura-rundeck-jobs#1

# Fixes
- 

# Todo
- [ ] Update Readme. But maybe best done in a separate ticket to prioritize with our other work for the 5.0 release
- [x] We still have use PyQt5 in this dependency, this is the root cause of CURA-9120 UFP files do not contain preview png file. Since we can't expect the Styx team to update to PyQt6 adhoc and on short notice we need find away to support both PyQt5 for Styx and PyQt6 for Cura. I suggest we handle that in CURA-9120