### PR TITLE
CMake consistency fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,27 @@
 project(charon NONE)
-cmake_minimum_required(VERSION 3.6) #Tested only with 3.6.1 and 3.9.1.
+cmake_minimum_required(VERSION 3.18)
 
-# FIXME: Remove the code for CMake <3.12 once we have switched over completely.
-# FindPython3 is a new module since CMake 3.12. It deprecates FindPythonInterp and FindPythonLibs.
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-    # Use FindPythonInterp and FindPythonLibs for CMake <3.12
-    find_package(PythonInterp 3.4 REQUIRED)
-
-    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-    set(Python3_VERSION_MAJOR ${PYTHON_VERSION_MAJOR})
-    set(Python3_VERSION_MINOR ${PYTHON_VERSION_MINOR})
-else()
-    # Use FindPython3 for CMake >=3.12
-    find_package(Python3 ${CURA_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+if(NOT DEFINED Python_VERSION)
+    set(Python_VERSION
+            3.10
+            CACHE STRING "Python Version" FORCE)
+    message(STATUS "Setting Python version to ${Python_VERSION}. Set Python_VERSION if you want to compile against an other version.")
+endif()
+if(APPLE)
+    set(Python_FIND_FRAMEWORK NEVER)
+endif()
+find_package(Python ${Python_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+message(STATUS "Linking and building ${project_name} against Python ${Python_VERSION}")
+if(NOT DEFINED Python_SITELIB_LOCAL)
+    set(Python_SITELIB_LOCAL
+            "${Python_SITELIB}"
+            CACHE PATH "Local alternative site-package location to install Cura" FORCE)
 endif()
 
 option(INSTALL_SERVICE "Install the Charon DBus-service" ON)
 option(INSTALL_CLIENT "Install the Charon Client library" ON)
 
-if(EXISTS /etc/debian_version)
-    set(CHARON_INSTALL_PATH lib${LIB_SUFFIX}/python${Python3_VERSION_MAJOR}/dist-packages)
-else()
-    set(CHARON_INSTALL_PATH lib${LIB_SUFFIX}/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages)
-endif()
-
-set(_excludes PATTERN __pycache__ EXCLUDE)
-if(NOT INSTALL_SERVICE)
-    set(_excludes ${_excludes} PATTERN "Service" EXCLUDE)
-endif()
-if(NOT INSTALL_CLIENT)
-    set(_excludes ${_excludes} PATTERN "Client" EXCLUDE)
-endif()
-
-install(DIRECTORY Charon DESTINATION ${CHARON_INSTALL_PATH} ${_excludes})
+install(DIRECTORY Charon DESTINATION "${Python_SITELIB_LOCAL}")
 
 if(INSTALL_SERVICE)
     install(FILES service/charon.service DESTINATION lib/systemd/system)
@@ -59,7 +48,7 @@ endif()
 
 add_test(
     NAME pytest-main
-    COMMAND ${Python3_EXECUTABLE} -m pytest --junitxml=${CMAKE_BINARY_DIR}/junit-pytest-main.xml ${CMAKE_SOURCE_DIR}/tests
+    COMMAND ${Python_EXECUTABLE} -m pytest --junitxml=${CMAKE_BINARY_DIR}/junit-pytest-main.xml ${CMAKE_SOURCE_DIR}/tests
 )
 set_tests_properties(pytest-main PROPERTIES ENVIRONMENT LANG=C)
 set_tests_properties(pytest-main PROPERTIES ENVIRONMENT "PYTHONPATH=${_PYTHONPATH}")


### PR DESCRIPTION
These are some changes that we made to the CMake build system to prepare for Cura 5.0.

From the [original PR](https://github.com/Ultimaker/Cura/pull/11792):

> In order to get this to work on our build-system and working for all three OSes we did a shit tons of boy scouting in our cmake. We removed old methods with variables and try to be consisted in a target-based approach. The idea is that we don't patch stuff down the line, but that the install should place everything in the correct path in a uniform way across all of Cura's dependencies. Most of these changes are in the other PR's. The CMakeLists.txt changes here are for consistency overal.

I'd suggest that you take a look at these changes to see how they can be adjusted for the build environment of the firmware. I don't expect the changes here to have a big impact on the way you're working though.

Contributes to issue CURA-8640.