### PR TITLE
Option to skip griffin header validation.

### DIFF
--- a/Charon/filetypes/GCodeFile.py
+++ b/Charon/filetypes/GCodeFile.py
@@ -69,7 +69,7 @@ class GCodeFile(FileInterface):
 
             flavor = metadata.get("flavor", None)
             if flavor == "Griffin":
-                if not SkipHeaderValidation and metadata["header_version"] != "0.1":
+                if not GCodeFile.SkipHeaderValidation and metadata["header_version"] != "0.1":
                     raise InvalidHeaderException("Unsupported Griffin header version: {0}".format(metadata["header_version"]))
                 try:
                     GCodeFile.__validateGriffinHeader(metadata)

--- a/Charon/filetypes/GCodeFile.py
+++ b/Charon/filetypes/GCodeFile.py
@@ -69,7 +69,7 @@ class GCodeFile(FileInterface):
 
             flavor = metadata.get("flavor", None)
             if flavor == "Griffin":
-                if metadata["header_version"] != "0.1" and not SkipHeaderValidation:
+                if not SkipHeaderValidation and metadata["header_version"] != "0.1":
                     raise InvalidHeaderException("Unsupported Griffin header version: {0}".format(metadata["header_version"]))
                 try:
                     GCodeFile.__validateGriffinHeader(metadata)


### PR DESCRIPTION
Files generated by the command line interface of CuraEngine are output in serial mode, meaning the header has to be printed before the print-time and material estimates are known. This will be needed for command-line tools we used to benchmark the engine with in the nightlies.

part of CURA-9495