### PR TITLE
boyscout: Fix missing SyslogIdentifier in SERVICE file

### DIFF
--- a/service/charon.service
+++ b/service/charon.service
@@ -11,6 +11,7 @@ BusName=nl.ultimaker.charon
 User=ultimaker
 Type=simple
 Restart=always
+SyslogIdentifier=Charon
 
 [Install]
 WantedBy=griffin.target


### PR DESCRIPTION
The Systemd SERVICE file for Charon was missing a `SyslogIdentifier` directive, causing log messages from Charon to show up in the system journal as originating from `python3`. This is not helpful.

Fix this, by explicitly marking log messages from Charon as `Charon`.