### PR TITLE
CES-2235 Delay DBus publication

### DIFF
--- a/Charon/Service/main.py
+++ b/Charon/Service/main.py
@@ -31,5 +31,6 @@ else:
     _bus = dbus.SystemBus(private=True, mainloop=dbus.mainloop.glib.DBusGMainLoop())
 
 _service = Charon.Service.FileService(_bus)
+_service.publish()
 
 _loop.run()

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ARCH="armhf"
 
@@ -42,7 +42,7 @@ usage()
     echo "NOTE: This script requires root permissions to run."
 }
 
-while getopts ":hc" options; do
+while getopts ":hcs" options; do
     case "${options}" in
     c)
         cleanup
@@ -51,6 +51,9 @@ while getopts ":hc" options; do
     h)
         usage
         exit 0
+        ;;
+    s)
+        # Ignore for compatibility with other build scripts
         ;;
     :)
         echo "Option -${OPTARG} requires an argument."

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2019 Ultimaker B.V.
 #
@@ -19,7 +19,7 @@ run_linters="yes"
 run_tests="yes"
 
 # Run the make_docker.sh script here, within the context of the build_for_ultimaker.sh script
-. ./make_docker.sh
+. ./make_docker.sh ""
 
 env_check()
 {
@@ -71,7 +71,7 @@ usage()
     echo "  -t   Skip tests"
 }
 
-while getopts ":chlt" options; do
+while getopts ":chlst" options; do
     case "${options}" in
     c)
         run_env_check="no"
@@ -85,6 +85,9 @@ while getopts ":chlt" options; do
         ;;
     t)
         run_tests="no"
+        ;;
+    s)
+        # Ignore for compatibility with other build scripts
         ;;
     :)
         echo "Option -${OPTARG} requires an argument."

--- a/docker_env/buildenv_check.sh
+++ b/docker_env/buildenv_check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 


### PR DESCRIPTION
Tweak the initialization order of the Charon DBus service. We should initially create the `dbus.service.Object` *without* claiming a well-known name on the bus. If we immediately claim a name within the `FileService.__init__()` initializer, the DBus service will (briefly) become visible on the DBus bus in a half-initialized state. The symptom of this is clients seeing empty or incomplete introspection data on `nl.ultimaker.charon`.
    
If, instead, we first allow `FileService` to completely finish its `__init__()`, and then separately claim the well-known name in `FileService.publish()`, this publishes the service to the bus "atomically".